### PR TITLE
Randomize collect interval (#18) and improve code readability

### DIFF
--- a/ASFFreeGames.Tests/RandomUtilsTests.cs
+++ b/ASFFreeGames.Tests/RandomUtilsTests.cs
@@ -1,0 +1,77 @@
+﻿#pragma warning disable CA1707 // Identifiers should not contain underscores
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Xunit;
+
+namespace Maxisoft.ASF.Tests;
+
+public class RandomUtilsTests {
+	// A static method to provide test data for the theory
+	public static TheoryData<double, double, int, double> GetTestData() =>
+		new TheoryData<double, double, int, double> {
+			// mean, std, sample size, margin of error
+			{ 0, 1, 1000, 0.05 }, // original test case
+			{ 10, 2, 1000, 0.1 }, // original test case
+			{ -5, 3, 5000, 0.15 }, // additional test case
+			{ 20, 5, 10000, 0.2 } // additional test case
+		};
+
+	// A test method to check if the mean and standard deviation of the normal distribution are close to the expected values
+	[Theory]
+	[MemberData(nameof(GetTestData))]
+	[SuppressMessage("ReSharper", "InconsistentNaming")]
+	public void NextGaussian_Should_Have_Expected_Mean_And_Std(double mean, double standardDeviation, int sampleSize, double marginOfError) {
+		// Arrange
+		using RandomUtils.GaussianRandom rng = new();
+
+		// Act
+		// Generate a large number of samples from the normal distribution
+		double[] samples = Enumerable.Range(0, sampleSize).Select(_ => rng.NextGaussian(mean, standardDeviation)).ToArray();
+
+		// Calculate the sample mean and sample standard deviation using local functions
+		double sampleMean = Mean(samples);
+		double sampleStd = StandardDeviation(samples);
+
+		// Assert
+		// Check if the sample mean and sample standard deviation are close to the expected values within the margin of error
+		Assert.InRange(sampleMean, mean - marginOfError, mean + marginOfError);
+		Assert.InRange(sampleStd, standardDeviation - marginOfError, standardDeviation + marginOfError);
+	}
+
+	// Local function to calculate the mean of a span of doubles
+	private static double Mean(ReadOnlySpan<double> values) {
+		// Check if the span is empty
+		if (values.IsEmpty) {
+			// Throw an exception
+			throw new InvalidOperationException("The span is empty.");
+		}
+
+		// Sum up all the values
+		double sum = 0;
+
+		foreach (double value in values) {
+			sum += value;
+		}
+
+		// Divide by the number of values
+		return sum / values.Length;
+	}
+
+	// Local function to calculate the standard deviation of a span of doubles
+	private static double StandardDeviation(ReadOnlySpan<double> values) {
+		// Calculate the mean using the local function
+		double mean = Mean(values);
+
+		// Sum up the squares of the differences from the mean
+		double sumOfSquares = 0;
+
+		foreach (double value in values) {
+			sumOfSquares += (value - mean) * (value - mean);
+		}
+
+		// Divide by the number of values and take the square root
+		return Math.Sqrt(sumOfSquares / values.Length);
+	}
+}
+#pragma warning restore CA1707 // Identifiers should not contain underscores

--- a/ASFFreeGames.Tests/RandomUtilsTests.cs
+++ b/ASFFreeGames.Tests/RandomUtilsTests.cs
@@ -11,10 +11,10 @@ public class RandomUtilsTests {
 	public static TheoryData<double, double, int, double> GetTestData() =>
 		new TheoryData<double, double, int, double> {
 			// mean, std, sample size, margin of error
-			{ 0, 1, 1000, 0.05 }, // original test case
-			{ 10, 2, 1000, 0.1 }, // original test case
-			{ -5, 3, 5000, 0.15 }, // additional test case
-			{ 20, 5, 10000, 0.2 } // additional test case
+			{ 0, 1, 10000, 0.05 },
+			{ 10, 2, 10000, 0.1 },
+			{ -5, 3, 50000, 0.15 },
+			{ 20, 5, 100000, 0.2 }
 		};
 
 	// A test method to check if the mean and standard deviation of the normal distribution are close to the expected values

--- a/ASFFreeGames/ASFFreeGamesPlugin.cs
+++ b/ASFFreeGames/ASFFreeGamesPlugin.cs
@@ -31,7 +31,7 @@ internal sealed class ASFFreeGamesPlugin : IASF, IBot, IBotConnection, IBotComma
 	private const int CollectGamesTimeout = 3 * 60 * 1000;
 
 	internal static PluginContext Context {
-		get => _context.Value;
+		get => _context.Value ?? new PluginContext(Array.Empty<Bot>(), new ContextRegistry(), new ASFFreeGamesOptions(), new LoggerFilter());
 		private set => _context.Value = value;
 	}
 
@@ -169,6 +169,7 @@ internal sealed class ASFFreeGamesPlugin : IASF, IBot, IBotConnection, IBotComma
 		LoggerFilter.RemoveFilters(bot);
 	}
 
+	// ReSharper disable once UnusedMethodReturnValue.Local
 	private async Task<string?> SaveOptions(CancellationToken cancellationToken) {
 		if (!cancellationToken.IsCancellationRequested) {
 			const string cmd = $"FREEGAMES {FreeGamesCommand.SaveOptionsInternalCommandString}";

--- a/ASFFreeGames/ASFFreeGamesPlugin.cs
+++ b/ASFFreeGames/ASFFreeGamesPlugin.cs
@@ -159,11 +159,11 @@ internal sealed class ASFFreeGamesPlugin : IASF, IBot, IBotConnection, IBotComma
 
 		StartTimerIfNeeded();
 
-		await BotContextRegistry.SaveBotContext(bot, new BotContext(bot), CancellationTokenSourceLazy.Value.Token).ConfigureAwait(false);
+		await BotContextRegistry.SaveBotContext(bot, new BotContext(bot), CancellationToken).ConfigureAwait(false);
 		BotContext? ctx = BotContextRegistry.GetBotContext(bot);
 
 		if (ctx is not null) {
-			await ctx.LoadFromFileSystem(CancellationTokenSourceLazy.Value.Token).ConfigureAwait(false);
+			await ctx.LoadFromFileSystem(CancellationToken).ConfigureAwait(false);
 		}
 	}
 

--- a/ASFFreeGames/ASFFreeGamesPlugin.cs
+++ b/ASFFreeGames/ASFFreeGamesPlugin.cs
@@ -54,7 +54,7 @@ internal sealed class ASFFreeGamesPlugin : IASF, IBot, IBotConnection, IBotComma
 	public ASFFreeGamesOptions Options => OptionsField;
 	private ASFFreeGamesOptions OptionsField = new();
 
-	private readonly CollectIntervalManager CollectIntervalManager;
+	private readonly ICollectIntervalManager CollectIntervalManager;
 
 	public ASFFreeGamesPlugin() {
 		CommandDispatcher = new CommandDispatcher(Options);

--- a/ASFFreeGames/CollectIntervalManager.cs
+++ b/ASFFreeGames/CollectIntervalManager.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Threading;
+
+namespace Maxisoft.ASF;
+
+internal sealed class CollectIntervalManager : IDisposable {
+	private static readonly RandomUtils.GaussianRandom Random = new();
+
+	/// <summary>
+	///     Gets a value that indicates whether to randomize the collect interval or not.
+	/// </summary>
+	/// <value>
+	///     A value of 1 if Options.RandomizeRecheckInterval is true or null, or a value of 0 otherwise.
+	/// </value>
+	/// <remarks>
+	///     This property is used to multiply the standard deviation of the normal distribution used to generate the random delay in the GetRandomizedTimerDelay method. If this property returns 0, then the random delay will be equal to the mean value.
+	/// </remarks>
+	private int RandomizeIntervalSwitch => Plugin.Options.RandomizeRecheckInterval ?? true ? 1 : 0;
+
+	// The reference to the plugin instance
+	private readonly IASFFreeGamesPlugin Plugin;
+
+	// The timer instance
+	private Timer? Timer;
+
+	// The constructor that takes a plugin instance as a parameter
+	public CollectIntervalManager(IASFFreeGamesPlugin plugin) => Plugin = plugin;
+
+	public void Dispose() => StopTimer();
+
+	// The public method that starts the timer if needed
+	public void StartTimerIfNeeded() {
+		if (Timer is null) {
+			// Get a random initial delay
+			TimeSpan initialDelay = GetRandomizedTimerDelay(30, 6 * RandomizeIntervalSwitch, 1, 5 * 60);
+
+			// Get a random regular delay
+			TimeSpan regularDelay = GetRandomizedTimerDelay(Plugin.Options.RecheckInterval.TotalSeconds, 7 * 60 * RandomizeIntervalSwitch);
+
+			// Create a new timer with the collect operation as the callback
+			Timer = new Timer(Plugin.CollectGamesOnClock);
+
+			// Start the timer with the initial and regular delays
+			Timer.Change(initialDelay, regularDelay);
+		}
+	}
+
+	/// <summary>
+	///     Calculates a random delay using a normal distribution with a mean of Options.RecheckInterval.TotalSeconds and a standard deviation of 7 minutes.
+	/// </summary>
+	/// <returns>The randomized delay.</returns>
+	/// <seealso cref="GetRandomizedTimerDelay(double, double, double, double)" />
+	private TimeSpan GetRandomizedTimerDelay() => GetRandomizedTimerDelay(Plugin.Options.RecheckInterval.TotalSeconds, 7 * 60 * RandomizeIntervalSwitch);
+
+	internal TimeSpan RandomlyChangeCollectInterval(object? source) {
+		// Calculate a random delay using GetRandomizedTimerDelay method
+		TimeSpan delay = GetRandomizedTimerDelay();
+		ResetTimer(() => new Timer(state => Plugin.CollectGamesOnClock(state), source, delay, delay));
+
+		return delay;
+	}
+
+	internal void StopTimer() => ResetTimer(null);
+
+	/// <summary>
+	///     Calculates a random delay using a normal distribution with a given mean and standard deviation.
+	/// </summary>
+	/// <param name="meanSeconds">The mean of the normal distribution in seconds.</param>
+	/// <param name="stdSeconds">The standard deviation of the normal distribution in seconds.</param>
+	/// <param name="minSeconds">The minimum value of the random delay in seconds. The default value is 11 minutes.</param>
+	/// <param name="maxSeconds">The maximum value of the random delay in seconds. The default value is 1 hour.</param>
+	/// <returns>The randomized delay.</returns>
+	/// <remarks>
+	///     The random number is clamped between the minSeconds and maxSeconds parameters.
+	///     This method uses the NextGaussian method from the RandomUtils class to generate normally distributed random numbers.
+	///     See [Random nextGaussian() method in Java with Examples] for more details on how to implement NextGaussian in C#.
+	/// </remarks>
+	private static TimeSpan GetRandomizedTimerDelay(double meanSeconds, double stdSeconds, double minSeconds = 11 * 60, double maxSeconds = 60 * 60) {
+		double randomNumber = stdSeconds != 0 ? Random.NextGaussian(meanSeconds, stdSeconds) : meanSeconds;
+
+		TimeSpan delay = TimeSpan.FromSeconds(randomNumber);
+
+		// Convert delay to seconds
+		double delaySeconds = delay.TotalSeconds;
+
+		// Clamp the delay between minSeconds and maxSeconds in seconds
+		delaySeconds = Math.Max(delaySeconds, minSeconds);
+		delaySeconds = Math.Min(delaySeconds, maxSeconds);
+
+		// Convert delay back to TimeSpan
+		delay = TimeSpan.FromSeconds(delaySeconds);
+
+		return delay;
+	}
+
+	private void ResetTimer(Func<Timer?>? newTimerFactory) {
+		Timer?.Dispose();
+		Timer = null;
+
+		if (newTimerFactory is not null) {
+			Timer = newTimerFactory();
+		}
+	}
+}

--- a/ASFFreeGames/CollectIntervalManager.cs
+++ b/ASFFreeGames/CollectIntervalManager.cs
@@ -3,7 +3,31 @@ using System.Threading;
 
 namespace Maxisoft.ASF;
 
-internal sealed class CollectIntervalManager : IDisposable {
+// The interface that defines the contract for the CollectIntervalManager class
+/// <inheritdoc />
+/// <summary>
+/// An interface that provides methods to manage the collect interval for the ASFFreeGamesPlugin.
+/// </summary>
+internal interface ICollectIntervalManager : IDisposable {
+	/// <summary>
+	/// Starts the timer with a random initial and regular delay if it is not already started.
+	/// </summary>
+	void StartTimerIfNeeded();
+
+	/// <summary>
+	/// Changes the collect interval to a new random value and resets the timer.
+	/// </summary>
+	/// <param name="source">The source object passed to the timer callback.</param>
+	/// <returns>The new random collect interval.</returns>
+	TimeSpan RandomlyChangeCollectInterval(object? source);
+
+	/// <summary>
+	/// Stops the timer and disposes it.
+	/// </summary>
+	void StopTimer();
+}
+
+internal sealed class CollectIntervalManager : ICollectIntervalManager {
 	private static readonly RandomUtils.GaussianRandom Random = new();
 
 	/// <summary>
@@ -52,7 +76,7 @@ internal sealed class CollectIntervalManager : IDisposable {
 	/// <seealso cref="GetRandomizedTimerDelay(double, double, double, double)" />
 	private TimeSpan GetRandomizedTimerDelay() => GetRandomizedTimerDelay(Plugin.Options.RecheckInterval.TotalSeconds, 7 * 60 * RandomizeIntervalSwitch);
 
-	internal TimeSpan RandomlyChangeCollectInterval(object? source) {
+	public TimeSpan RandomlyChangeCollectInterval(object? source) {
 		// Calculate a random delay using GetRandomizedTimerDelay method
 		TimeSpan delay = GetRandomizedTimerDelay();
 		ResetTimer(() => new Timer(state => Plugin.CollectGamesOnClock(state), source, delay, delay));
@@ -60,7 +84,7 @@ internal sealed class CollectIntervalManager : IDisposable {
 		return delay;
 	}
 
-	internal void StopTimer() => ResetTimer(null);
+	public void StopTimer() => ResetTimer(null);
 
 	/// <summary>
 	///     Calculates a random delay using a normal distribution with a given mean and standard deviation.

--- a/ASFFreeGames/Configurations/ASFFreeGamesOptions.cs
+++ b/ASFFreeGames/Configurations/ASFFreeGamesOptions.cs
@@ -14,7 +14,7 @@ namespace Maxisoft.ASF {
 
 		// Use Nullable<T> instead of bool? for nullable value types
 		[JsonProperty("randomizeRecheckInterval")]
-		public Nullable<TimeSpan> RandomizeRecheckInterval { get; set; }
+		public Nullable<bool> RandomizeRecheckInterval { get; set; }
 
 		[JsonProperty("skipFreeToPlay")]
 		public Nullable<bool> SkipFreeToPlay { get; set; }

--- a/ASFFreeGames/Configurations/ASFFreeGamesOptionsLoader.cs
+++ b/ASFFreeGames/Configurations/ASFFreeGamesOptionsLoader.cs
@@ -25,8 +25,7 @@ public static class ASFFreeGamesOptionsLoader {
 			options.RecheckInterval = TimeSpan.FromMilliseconds(configurationRoot.GetValue("RecheckIntervalMs", options.RecheckInterval.TotalMilliseconds));
 			options.SkipFreeToPlay = configurationRoot.GetValue("SkipFreeToPlay", options.SkipFreeToPlay);
 			options.SkipDLC = configurationRoot.GetValue("SkipDLC", options.SkipDLC);
-			double? randomizeRecheckInterval = configurationRoot.GetValue("RandomizeRecheckIntervalMs", options.RandomizeRecheckInterval?.TotalMilliseconds);
-			options.RandomizeRecheckInterval = randomizeRecheckInterval is not null ? TimeSpan.FromMilliseconds(randomizeRecheckInterval.Value) : null;
+			options.RandomizeRecheckInterval = configurationRoot.GetValue("RandomizeRecheckInterval", options.RandomizeRecheckInterval);
 		}
 		finally {
 			Semaphore.Release();

--- a/ASFFreeGames/PluginContext.cs
+++ b/ASFFreeGames/PluginContext.cs
@@ -5,6 +5,6 @@ using ArchiSteamFarm.Steam;
 
 namespace Maxisoft.ASF;
 
-internal readonly record struct PluginContext(IReadOnlyCollection<Bot> Bots, IContextRegistry BotContexts, ASFFreeGamesOptions Options, LoggerFilter LoggerFilter, Lazy<CancellationToken> CancellationTokenLazy) {
+internal readonly record struct PluginContext(IReadOnlyCollection<Bot> Bots, IContextRegistry BotContexts, ASFFreeGamesOptions Options, LoggerFilter LoggerFilter, Lazy<CancellationToken> CancellationTokenLazy, bool Valid = false) {
 	public CancellationToken CancellationToken => CancellationTokenLazy.Value;
 }

--- a/ASFFreeGames/PluginContext.cs
+++ b/ASFFreeGames/PluginContext.cs
@@ -5,6 +5,43 @@ using ArchiSteamFarm.Steam;
 
 namespace Maxisoft.ASF;
 
-internal readonly record struct PluginContext(IReadOnlyCollection<Bot> Bots, IContextRegistry BotContexts, ASFFreeGamesOptions Options, LoggerFilter LoggerFilter, Lazy<CancellationToken> CancellationTokenLazy, bool Valid = false) {
+internal sealed record PluginContext(IReadOnlyCollection<Bot> Bots, IContextRegistry BotContexts, ASFFreeGamesOptions Options, LoggerFilter LoggerFilter, bool Valid = false) {
+	/// <summary>
+	/// Gets the cancellation token associated with this context.
+	/// </summary>
 	public CancellationToken CancellationToken => CancellationTokenLazy.Value;
+
+	internal Lazy<CancellationToken> CancellationTokenLazy { private get; set; } = new(default(CancellationToken));
+
+	/// <summary>
+	/// A struct that implements IDisposable and temporarily changes the cancellation token of the PluginContext instance.
+	/// </summary>
+	public readonly struct CancellationTokenChanger : IDisposable {
+		private readonly PluginContext Context;
+		private readonly Lazy<CancellationToken> Original;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="CancellationTokenChanger"/> struct with the specified context and factory.
+		/// </summary>
+		/// <param name="context">The PluginContext instance to change.</param>
+		/// <param name="factory">The function that creates a new cancellation token.</param>
+		public CancellationTokenChanger(PluginContext context, Func<CancellationToken> factory) {
+			Context = context;
+			Original = context.CancellationTokenLazy;
+			context.CancellationTokenLazy = new Lazy<CancellationToken>(factory);
+		}
+
+		/// <inheritdoc />
+		/// <summary>
+		/// Restores the original cancellation token to the PluginContext instance.
+		/// </summary>
+		public void Dispose() => Context.CancellationTokenLazy = Original;
+	}
+
+	/// <summary>
+	/// Creates a new instance of the <see cref="CancellationTokenChanger"/> struct with the specified factory.
+	/// </summary>
+	/// <param name="factory">The function that creates a new cancellation token.</param>
+	/// <returns>A new instance of the <see cref="CancellationTokenChanger"/> struct.</returns>
+	public CancellationTokenChanger TemporaryChangeCancellationToken(Func<CancellationToken> factory) => new(this, factory);
 }

--- a/ASFFreeGames/RandomUtils.cs
+++ b/ASFFreeGames/RandomUtils.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+
+namespace Maxisoft.ASF;
+
+#nullable enable
+
+public static class RandomUtils {
+	/// <summary>
+	///     Generates a random number from a normal distribution with the specified mean and standard deviation.
+	/// </summary>
+	/// <param name="random">The random number generator to use.</param>
+	/// <param name="mean">The mean of the normal distribution.</param>
+	/// <param name="standardDeviation">The standard deviation of the normal distribution.</param>
+	/// <returns>A random number from the normal distribution.</returns>
+	/// <remarks>
+	///     This method uses the Box-Muller transform to convert two uniformly distributed random numbers into two normally distributed random numbers.
+	/// </remarks>
+	public static double NextGaussian([NotNull] this RandomNumberGenerator random, double mean, double standardDeviation) {
+		Debug.Assert(random != null, nameof(random) + " != null");
+
+		// Generate two uniform random numbers
+		Span<byte> bytes = stackalloc byte[8];
+		random.GetBytes(bytes);
+		double u1 = BitConverter.ToUInt32(bytes) / (double) uint.MaxValue;
+		random.GetBytes(bytes);
+		double u2 = BitConverter.ToUInt32(bytes) / (double) uint.MaxValue;
+
+		// Apply the Box-Muller formula
+		double randStdNormal = Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Sin(2.0 * Math.PI * u2);
+
+		// Scale and shift to get a random number with the desired mean and standard deviation
+		double randNormal = mean + (standardDeviation * randStdNormal);
+
+		return randNormal;
+	}
+
+	internal sealed class GaussianRandom : RandomNumberGenerator {
+		// A flag to indicate if there is a stored value for the next Gaussian number
+		private bool HasNextGaussian;
+
+		// The stored value for the next Gaussian number
+		private double NextGaussianValue;
+
+		public override void GetBytes(byte[] data) => Fill(data);
+
+		public override void GetNonZeroBytes(byte[] data) => Fill(data);
+
+		private double NextDouble() {
+			if (HasNextGaussian) {
+				HasNextGaussian = false;
+
+				return NextGaussianValue;
+			}
+
+			// Generate two uniform random numbers
+			Span<byte> bytes = stackalloc byte[8];
+			GetBytes(bytes);
+			float u1 = BitConverter.ToUInt32(bytes) / (float) uint.MaxValue;
+			GetBytes(bytes);
+			float u2 = BitConverter.ToUInt32(bytes) / (float) uint.MaxValue;
+
+			// Apply the Box-Muller formula
+			float r = MathF.Sqrt(-2.0f * MathF.Log(u1));
+			float theta = 2.0f * MathF.PI * u2;
+
+			// Store one of the values for next time
+			NextGaussianValue = r * MathF.Sin(theta);
+			HasNextGaussian = true;
+
+			// Return the other value
+			return r * MathF.Cos(theta);
+		}
+
+		/// <summary>
+		///     Generates a random number from a normal distribution with the specified mean and standard deviation.
+		/// </summary>
+		/// <param name="mean">The mean of the normal distribution.</param>
+		/// <param name="standardDeviation">The standard deviation of the normal distribution.</param>
+		/// <returns>A random number from the normal distribution.</returns>
+		/// <remarks>
+		///     This method uses the overridden NextDouble method to get a normally distributed random number.
+		/// </remarks>
+		public double NextGaussian(double mean, double standardDeviation) =>
+
+			// Use the overridden NextDouble method to get a normally distributed random number
+			mean + (standardDeviation * NextDouble());
+	}
+}


### PR DESCRIPTION
## What?
This pull request adds a new feature that randomizes the collect interval using a normal distribution with a mean of 30 minutes and a standard deviation of 7 minutes.

## Why?
This feature resolves #18 by adding more randomness and flexibility to the collect interval. It also makes the code more efficient and readable by refactoring and simplifying some methods.

## How?
This pull request implements the following changes:

- Add a new option to the ASFFreeGamesOptions class called RandomizeRecheckInterval, which is a nullable bool that indicates whether to randomize the collect interval or not.
- Modify the ASFFreeGamesPlugin class to use the RandomizeRecheckInterval option to determine the value of the RandomizeIntervalSwitch property, which is used to multiply the standard deviation of the normal distribution used to generate the random delay in the GetRandomizedTimerDelay method.
- Extract an interface called IASFFreeGamesPlugin from the ASFFreeGamesPlugin class, which contains the members that are used by the CollectIntervalManager class.
- Move the timer and random delay logic from the ASFFreeGamesPlugin class to the CollectIntervalManager class, which encapsulates the functionality of managing the collect interval.

## Testing?
To test this feature, you can run the unit tests in RandomUtilsTests.cs and check if they pass. You can also run the plugin with different values of RandomizeRecheckInterval and observe how it affects the collect interval.

## Screenshots (optional)
N/A

## Anything Else?
N/A
