### PR TITLE
Fix System.MissingMethodException occurring in trimmed ASF binary

### DIFF
--- a/ASFFreeGames/PluginContext.cs
+++ b/ASFFreeGames/PluginContext.cs
@@ -11,7 +11,7 @@ internal sealed record PluginContext(IReadOnlyCollection<Bot> Bots, IContextRegi
 	/// </summary>
 	public CancellationToken CancellationToken => CancellationTokenLazy.Value;
 
-	internal Lazy<CancellationToken> CancellationTokenLazy { private get; set; } = new(default(CancellationToken));
+	internal Lazy<CancellationToken> CancellationTokenLazy { private get; set; } = new(static () => default(CancellationToken));
 
 	/// <summary>
 	/// A struct that implements IDisposable and temporarily changes the cancellation token of the PluginContext instance.


### PR DESCRIPTION
The Lazy<T> constructor that takes a value parameter is trimmed in the official ASF binary, which causes a System.MissingMethodException when the plugin tries to access it. This commit fixes this issue by using a static lambda expression that returns the default cancellation token instead.

This commit closes #43.

## Pull request

