### PR TITLE
Resolve KeyNotFoundException and Enhance Bot Handling in Free Game Collection

### DIFF
--- a/ASFFreeGames/ASFFreeGamesPlugin.cs
+++ b/ASFFreeGames/ASFFreeGamesPlugin.cs
@@ -127,6 +127,12 @@ internal sealed class ASFFreeGamesPlugin : IASF, IBot, IBotConnection, IBotComma
 				Array.Sort(reorderedBots, comparison);
 			}
 
+			if (reorderedBots.Length == 0) {
+				ArchiLogger.LogGenericDebug("no viable bot found for freegame scheduled operation");
+
+				return;
+			}
+
 			if (!cts.IsCancellationRequested) {
 				string cmd = $"FREEGAMES {FreeGamesCommand.CollectInternalCommandString} " + string.Join(' ', reorderedBots.Select(static bot => bot.BotName));
 				await OnBotCommand(null!, EAccess.None, cmd, cmd.Split()).ConfigureAwait(false);

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 
 	<PropertyGroup>
 		<PluginName>ASFFreeGames</PluginName>
-		<Version>1.5.1.0</Version>
+		<Version>1.5.2.0</Version>
 		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 


### PR DESCRIPTION
## Overview
This pull request addresses the `KeyNotFoundException` during the scheduled free game collection process and implements enhancements to bot handling. The changes are a direct response to the issue reported in #70.

## Changes
- **ASFFreeGamesPlugin.cs**: Introduced a pre-check for viable bots before initiating the free game collection command to prevent attempts to access keys that do not exist in the bot dictionary.
- **FreeGamesCommand.cs**: Refined bot collection handling by trimming bot names to eliminate whitespace issues and employing `GetValueOrDefault` for safer retrieval of bot instances, thereby avoiding potential exceptions.
- **Command Handling**: The `HandleInternalCollectCommand` method now provides a more detailed response, clearly stating the total number of games collected and enumerating the bots that participated in the operation.

## Impact
These improvements are expected to significantly increase the stability and reliability of the free game collection feature within ASF, ensuring smoother operations and better user experience.

## Additional Notes
- Version bump to 1.5.2 to reflect the new changes and fixes.
