### PR TITLE
Update for latest afs trimmed changes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 
 	<PropertyGroup>
 		<PluginName>ASFFreeGames</PluginName>
-		<Version>1.7.0.0</Version>
+		<Version>1.7.1.0</Version>
 		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 


### PR DESCRIPTION
Use SocketsHttpHandler & Implement property access with reflection for resiliency (fix #99)

Change HttpClientHandler to SocketsHttpHandler to match ArchiSteamFarm upstream code This commit addresses the issue raised in #99 by using reflection to set properties on `SocketsHttpHandler` and `HttpClient`. This ensures that our code continues to function even if the property names are changed or deleted in a future trimmed binary.

**Changes:**

* Modified `SimpleHttpClient` constructor to use reflection-based property setting for:
    * `AutomaticDecompression`
    * `MaxConnectionsPerServer`
    * `EnableMultipleHttp2Connections`
* Added a new helper method `SetPropertyValue` for generic property access with logging.
* Updated `SetExpectContinueProperty` to use reflection as well.
* Introduced a new method `SetPropertyWithLogging` to handle potential exceptions and log warnings if property access fails.
* Updated `Directory.Build.props` to increment the version to `1.7.1.0`.

**Additional Notes:**

* Reflection can be slightly slower than direct property access. However, this approach offers greater flexibility and resilience to potential changes in the underlying libraries.

**This commit is related to issue #99.**

