### PR TITLE
Implement GitHub update checks (v1.8.x)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,9 @@ jobs:
             seven_zip_args="-mx=1"
             zip_args="-1"
 
+            # Remove useless dlls
+            rm -rf out/${1}/${PLUGIN_NAME}/System.IO.Hashing.dll out/${1}/${PLUGIN_NAME}/NLog.dll out/${1}/${PLUGIN_NAME}/SteamKit2.dll out/${1}/${PLUGIN_NAME}/System.IO.Hashing.dll out/${1}/${PLUGIN_NAME}/protobuf-net.Core.dll out/${1}/${PLUGIN_NAME}/protobuf-net.dll
+
             # Include extra logic for builds marked for release
             case "$GITHUB_REF" in
                 "refs/tags/"*)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,6 +147,14 @@ jobs:
                 $compressionArgs = '-mx=9', '-mfb=258', '-mpass=15'
             }
 
+            # Remove useless dlls
+            Get-Item "$env:GITHUB_WORKSPACE\out\$variant\$env:PLUGIN_NAME\System.IO.Hashing.dll" -ErrorAction SilentlyContinue | Remove-Item
+            Get-Item "$env:GITHUB_WORKSPACE\out\$variant\$env:PLUGIN_NAME\NLog.dll" -ErrorAction SilentlyContinue | Remove-Item
+            Get-Item "$env:GITHUB_WORKSPACE\out\$variant\$env:PLUGIN_NAME\SteamKit2.dll" -ErrorAction SilentlyContinue | Remove-Item
+            Get-Item "$env:GITHUB_WORKSPACE\out\$variant\$env:PLUGIN_NAME\System.IO.Hashing.dll" -ErrorAction SilentlyContinue | Remove-Item
+            Get-Item "$env:GITHUB_WORKSPACE\out\$variant\$env:PLUGIN_NAME\protobuf-net.Core.dll" -ErrorAction SilentlyContinue | Remove-Item
+            Get-Item "$env:GITHUB_WORKSPACE\out\$variant\$env:PLUGIN_NAME\protobuf-net.dll" -ErrorAction SilentlyContinue | Remove-Item
+
             # Create the final zip file
             7z a -bd -slp -tzip -mm=Deflate $compressionArgs "out\$env:PLUGIN_NAME-$variant.zip" "$env:GITHUB_WORKSPACE\out\$variant\*"
 

--- a/ASFFreeGames/Github/GithubPluginUpdater.cs
+++ b/ASFFreeGames/Github/GithubPluginUpdater.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using ArchiSteamFarm;
+using ArchiSteamFarm.Localization;
+using ArchiSteamFarm.Web.GitHub;
+using ArchiSteamFarm.Web.GitHub.Data;
+
+namespace Maxisoft.ASF.Github;
+
+public class GithubPluginUpdater(Lazy<Version> version) {
+	public const string RepositoryName = "maxisoft/ASFFreeGames";
+	public bool CanUpdate { get; internal set; } = true;
+
+	private Version CurrentVersion => version.Value;
+
+	public async Task<Uri?> GetTargetReleaseURL(Version asfVersion, string asfVariant, bool asfUpdate, bool stable, bool forced) {
+		ArgumentNullException.ThrowIfNull(asfVersion);
+		ArgumentException.ThrowIfNullOrEmpty(asfVariant);
+
+		if (!CanUpdate) {
+			return null;
+		}
+
+		if (string.IsNullOrEmpty(RepositoryName)) {
+			//ArchiSteamFarm.Core.ASF.ArchiLogger.LogGenericError(Strings.FormatWarningFailedWithError(nameof(RepositoryName)));
+
+			return null;
+		}
+
+		ReleaseResponse? releaseResponse = await GitHubService.GetLatestRelease(RepositoryName).ConfigureAwait(false);
+
+		if (releaseResponse == null) {
+			return null;
+		}
+
+		if (releaseResponse.IsPreRelease) {
+			return null;
+		}
+
+		Version newVersion = new(releaseResponse.Tag.ToUpperInvariant().TrimStart('V'));
+
+		if (!forced && (CurrentVersion >= newVersion)) {
+			// Allow same version to be re-updated when we're updating ASF release and more than one asset is found - potential compatibility difference
+			if ((CurrentVersion > newVersion) || !asfUpdate || (releaseResponse.Assets.Count(static asset => asset.Name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)) < 2)) {
+				//ASF.ArchiLogger.LogGenericInfo(Strings.FormatPluginUpdateNotFound(Name, Version, newVersion));
+
+				return null;
+			}
+		}
+
+		if (releaseResponse.Assets.Count == 0) {
+			//ASF.ArchiLogger.LogGenericWarning(Strings.FormatPluginUpdateNoAssetFound(Name, Version, newVersion));
+
+			return null;
+		}
+
+		ReleaseAsset? asset = releaseResponse.Assets.FirstOrDefault(static asset => asset.Name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) && (asset.Size > (1 << 18)));
+
+		if ((asset == null) || !releaseResponse.Assets.Contains(asset)) {
+			//ASF.ArchiLogger.LogGenericWarning(Strings.FormatPluginUpdateNoAssetFound(Name, Version, newVersion));
+
+			return null;
+		}
+
+		//.ArchiLogger.LogGenericInfo(Strings.FormatPluginUpdateFound(Name, Version, newVersion));
+
+		return asset.DownloadURL;
+	}
+}

--- a/ASFFreeGames/Github/GithubPluginUpdater.cs
+++ b/ASFFreeGames/Github/GithubPluginUpdater.cs
@@ -38,7 +38,7 @@ public class GithubPluginUpdater(Lazy<Version> version) {
 			return null;
 		}
 
-		if (stable && !((releaseResponse.PublishedAt - DateTime.UtcNow).Duration() > TimeSpan.FromHours(12))) {
+		if (stable && !((releaseResponse.PublishedAt - DateTime.UtcNow).Duration() > TimeSpan.FromHours(3))) {
 			// Skip updates that are too recent
 			return null;
 		}

--- a/ASFFreeGames/Github/GithubPluginUpdater.cs
+++ b/ASFFreeGames/Github/GithubPluginUpdater.cs
@@ -38,6 +38,11 @@ public class GithubPluginUpdater(Lazy<Version> version) {
 			return null;
 		}
 
+		if (stable && !((releaseResponse.PublishedAt - DateTime.UtcNow).Duration() > TimeSpan.FromHours(12))) {
+			// Skip updates that are too recent
+			return null;
+		}
+
 		Version newVersion = new(releaseResponse.Tag.ToUpperInvariant().TrimStart('V'));
 
 		if (!forced && (CurrentVersion >= newVersion)) {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 
 	<PropertyGroup>
 		<PluginName>ASFFreeGames</PluginName>
-		<Version>1.7.1.0</Version>
+		<Version>1.8.0.0</Version>
 		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ The environment variable takes precedence over the config file setting.
 The plugin supports checking for updates on GitHub. You can enable automatic updates by modifying the `PluginsUpdateList` property in your ArchiSteamFarm configuration (refer to the [ArchiSteamFarm wiki](https://github.com/JustArchiNET/ArchiSteamFarm/wiki/Configuration#pluginsupdatelist) for details).
 
 **Important note:** Enabling automatic updates for plugins can have security implications. It's recommended to thoroughly test updates in a non-production environment before enabling them on your main system.
----
+
+
+------
 ## Dev notes
 
 ### Compilation

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ The environment variable takes precedence over the config file setting.
 ### Log is full of `Request failed after 5 attempts!` messages is there something wrong ?   
 
 - There's nothing wrong (most likely), those error messages are the result of the plugin trying to add a steam key which is unavailable. With time those errors should occurs less frequently (see [#3](https://github.com/maxisoft/ASFFreeGames/issues/3) for more details).
+
+
+### How to configure automatic updates for the plugin?
+The plugin supports checking for updates on GitHub. You can enable automatic updates by modifying the `PluginsUpdateList` property in your ArchiSteamFarm configuration (refer to the [ArchiSteamFarm wiki](https://github.com/JustArchiNET/ArchiSteamFarm/wiki/Configuration#pluginsupdatelist) for details).
+
+**Important note:** Enabling automatic updates for plugins can have security implications. It's recommended to thoroughly test updates in a non-production environment before enabling them on your main system.
 ---
 ## Dev notes
 


### PR DESCRIPTION
* **Implemented automatic update check via GitHub:** The `ASFFreeGamesPlugin` now supports checking for updates through GitHub. Note that this feature is currently disabled by default in ASF.
* **Added `GithubPluginUpdater` class:** This class handles communication with GitHub to retrieve the latest release information.
* **Updated version number:** The plugin version is bumped to `1.8.0.0`.
* **Removed unnecessary dependencies:** The build process now excludes unnecessary DLLs from the final package.

**Fixes issue #101.**

