### PR TITLE
Fix(tests): Replace ConfigureAwait(false) with ConfigureAwait(true) to address xUnit warnings

### DIFF
--- a/ASFFreeGames.Tests/Configurations/ASFFreeGamesOptionsSaverTests.cs
+++ b/ASFFreeGames.Tests/Configurations/ASFFreeGamesOptionsSaverTests.cs
@@ -12,7 +12,7 @@ namespace Maxisoft.ASF.Tests.Configurations;
 public class ASFFreeGamesOptionsSaverTests {
 	[Fact]
 #pragma warning disable CA1707
-	public async Task SaveOptions_WritesValidJson_And_ParsesCorrectly() {
+	public async Task SaveOptions_WritesValidJson_ParsesCorrectly() {
 #pragma warning restore CA1707
 
 		// Arrange

--- a/ASFFreeGames.Tests/Configurations/ASFFreeGamesOptionsSaverTests.cs
+++ b/ASFFreeGames.Tests/Configurations/ASFFreeGamesOptionsSaverTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Tasks;
 using ASFFreeGames.Configurations;
 using Xunit;
 
@@ -11,7 +12,7 @@ namespace Maxisoft.ASF.Tests.Configurations;
 public class ASFFreeGamesOptionsSaverTests {
 	[Fact]
 #pragma warning disable CA1707
-	public async void SaveOptions_WritesValidJson_And_ParsesCorrectly() {
+	public async Task SaveOptions_WritesValidJson_And_ParsesCorrectly() {
 #pragma warning restore CA1707
 
 		// Arrange
@@ -34,7 +35,7 @@ public class ASFFreeGamesOptionsSaverTests {
 		using MemoryStream memoryStream = new();
 
 		// Act
-		_ = await ASFFreeGamesOptionsSaver.SaveOptions(memoryStream, options).ConfigureAwait(false);
+		_ = await ASFFreeGamesOptionsSaver.SaveOptions(memoryStream, options).ConfigureAwait(true);
 
 		// Assert - Validate UTF-8 encoding
 		memoryStream.Position = 0;

--- a/ASFFreeGames.Tests/Reddit/RedditHelperTests.cs
+++ b/ASFFreeGames.Tests/Reddit/RedditHelperTests.cs
@@ -16,7 +16,7 @@ namespace Maxisoft.ASF.Tests.Reddit;
 public sealed class RedditHelperTests {
 	[Fact]
 	public async Task TestNotEmpty() {
-		RedditGameEntry[] entries = await LoadAsfinfoEntries().ConfigureAwait(false);
+		RedditGameEntry[] entries = await LoadAsfinfoEntries().ConfigureAwait(true);
 		Assert.NotEmpty(entries);
 	}
 
@@ -24,13 +24,13 @@ public sealed class RedditHelperTests {
 	[InlineData("s/762440")]
 	[InlineData("a/1601550")]
 	public async Task TestContains(string appid) {
-		RedditGameEntry[] entries = await LoadAsfinfoEntries().ConfigureAwait(false);
+		RedditGameEntry[] entries = await LoadAsfinfoEntries().ConfigureAwait(true);
 		Assert.Contains(new RedditGameEntry(appid, default(ERedditGameEntryKind), long.MaxValue), entries, new GameEntryIdentifierEqualityComparer());
 	}
 
 	[Fact]
 	public async Task TestMaintainOrder() {
-		RedditGameEntry[] entries = await LoadAsfinfoEntries().ConfigureAwait(false);
+		RedditGameEntry[] entries = await LoadAsfinfoEntries().ConfigureAwait(true);
 		int app762440 = Array.FindIndex(entries, static entry => entry.Identifier == "s/762440");
 		int app1601550 = Array.FindIndex(entries, static entry => entry.Identifier == "a/1601550");
 		Assert.InRange(app762440, 0, long.MaxValue);
@@ -43,17 +43,17 @@ public sealed class RedditHelperTests {
 
 	[Fact]
 	public async Task TestFreeToPlayParsing() {
-		RedditGameEntry[] entries = await LoadAsfinfoEntries().ConfigureAwait(false);
-		RedditGameEntry f2pEntry = Array.Find(entries, static entry => entry.Identifier == "a/1631250");
-		Assert.True(f2pEntry.IsFreeToPlay);
+		RedditGameEntry[] entries = await LoadAsfinfoEntries().ConfigureAwait(true);
+		RedditGameEntry f2PEntry = Array.Find(entries, static entry => entry.Identifier == "a/1631250");
+		Assert.True(f2PEntry.IsFreeToPlay);
 
 		RedditGameEntry getEntry(string identifier) => Array.Find(entries, entry => entry.Identifier == identifier);
 
-		f2pEntry = getEntry("a/431650"); // F2P
-		Assert.True(f2pEntry.IsFreeToPlay);
+		f2PEntry = getEntry("a/431650"); // F2P
+		Assert.True(f2PEntry.IsFreeToPlay);
 
-		f2pEntry = getEntry("a/579730");
-		Assert.True(f2pEntry.IsFreeToPlay);
+		f2PEntry = getEntry("a/579730");
+		Assert.True(f2PEntry.IsFreeToPlay);
 
 		RedditGameEntry dlcEntry = getEntry("s/791643"); // DLC
 		Assert.False(dlcEntry.IsFreeToPlay);
@@ -70,17 +70,17 @@ public sealed class RedditHelperTests {
 
 	[Fact]
 	public async Task TestDlcParsing() {
-		RedditGameEntry[] entries = await LoadAsfinfoEntries().ConfigureAwait(false);
-		RedditGameEntry f2pEntry = Array.Find(entries, static entry => entry.Identifier == "a/1631250");
-		Assert.False(f2pEntry.IsForDlc);
+		RedditGameEntry[] entries = await LoadAsfinfoEntries().ConfigureAwait(true);
+		RedditGameEntry f2PEntry = Array.Find(entries, static entry => entry.Identifier == "a/1631250");
+		Assert.False(f2PEntry.IsForDlc);
 
 		RedditGameEntry getEntry(string identifier) => Array.Find(entries, entry => entry.Identifier == identifier);
 
-		f2pEntry = getEntry("a/431650"); // F2P
-		Assert.False(f2pEntry.IsForDlc);
+		f2PEntry = getEntry("a/431650"); // F2P
+		Assert.False(f2PEntry.IsForDlc);
 
-		f2pEntry = getEntry("a/579730");
-		Assert.False(f2pEntry.IsForDlc);
+		f2PEntry = getEntry("a/579730");
+		Assert.False(f2PEntry.IsForDlc);
 
 		RedditGameEntry dlcEntry = getEntry("s/791643"); // DLC
 		Assert.True(dlcEntry.IsForDlc);

--- a/ASFFreeGames.Tests/Redlib/RedlibHtmlParserTests.cs
+++ b/ASFFreeGames.Tests/Redlib/RedlibHtmlParserTests.cs
@@ -13,8 +13,8 @@ namespace Maxisoft.ASF.Tests.Redlib;
 
 public class RedlibHtmlParserTests {
 	[Fact]
-	public async void Test() {
-		string html = await LoadHtml().ConfigureAwait(false);
+	public async Task Test() {
+		string html = await LoadHtml().ConfigureAwait(true);
 
 		// ReSharper disable once ArgumentsStyleLiteral
 		IReadOnlyCollection<RedlibGameEntry> result = RedlibHtmlParser.ParseGamesFromHtml(html, dedup: false);

--- a/ASFFreeGames.Tests/Redlib/RedlibInstancesListTests.cs
+++ b/ASFFreeGames.Tests/Redlib/RedlibInstancesListTests.cs
@@ -15,9 +15,9 @@ namespace Maxisoft.ASF.Tests.Redlib;
 
 public class RedlibInstanceListTests {
 	[Fact]
-	public async void Test() {
+	public async Task Test() {
 		RedlibInstanceList lister = new(new ASFFreeGamesOptions());
-		List<Uri> uris = await RedlibInstanceList.ListFromEmbedded(default(CancellationToken)).ConfigureAwait(false);
+		List<Uri> uris = await RedlibInstanceList.ListFromEmbedded(CancellationToken.None).ConfigureAwait(true);
 
 		Assert.NotEmpty(uris);
 	}

--- a/ASFFreeGames/Redlib/Instances/RedlibInstanceList.cs
+++ b/ASFFreeGames/Redlib/Instances/RedlibInstanceList.cs
@@ -12,121 +12,119 @@ using ASFFreeGames.Configurations;
 using Maxisoft.ASF.HttpClientSimple;
 using Maxisoft.ASF.Reddit;
 
+#nullable enable
+
 // ReSharper disable once CheckNamespace
 namespace Maxisoft.ASF.Redlib.Instances;
 
 [SuppressMessage("ReSharper", "RedundantNullableFlowAttribute")]
-public class RedlibInstanceList : IRedlibInstanceList {
-    private const string EmbeddedFileName = "redlib_instances.json";
+public class RedlibInstanceList(ASFFreeGamesOptions options) : IRedlibInstanceList {
+	private const string EmbeddedFileName = "redlib_instances.json";
 
-    private static readonly HashSet<string> DisabledKeywords = new(StringComparer.OrdinalIgnoreCase) {
-        "disabled",
-        "off",
-        "no",
-        "false"
-    };
+	private static readonly HashSet<string> DisabledKeywords = new(StringComparer.OrdinalIgnoreCase) {
+		"disabled",
+		"off",
+		"no",
+		"false"
+	};
 
-    private readonly ASFFreeGamesOptions options;
+	private readonly ASFFreeGamesOptions Options = options ?? throw new ArgumentNullException(nameof(options));
 
-    public RedlibInstanceList(ASFFreeGamesOptions options) {
-        this.options = options ?? throw new ArgumentNullException(nameof(options));
-    }
+	public async Task<List<Uri>> ListInstances([NotNull] SimpleHttpClient httpClient, CancellationToken cancellationToken) {
+		if (IsDisabled(Options.RedlibInstanceUrl)) {
+			throw new RedlibDisabledException();
+		}
 
-    public async Task<List<Uri>> ListInstances([NotNull] SimpleHttpClient httpClient, CancellationToken cancellationToken) {
-        if (IsDisabled(options.RedlibInstanceUrl)) {
-            throw new RedlibDisabledException();
-        }
+		if (!Uri.TryCreate(Options.RedlibInstanceUrl, UriKind.Absolute, out Uri? uri)) {
+			ArchiSteamFarm.Core.ASF.ArchiLogger.LogGenericError("[FreeGames] Invalid redlib instances url: " + Options.RedlibInstanceUrl);
 
-        if (!Uri.TryCreate(options.RedlibInstanceUrl, UriKind.Absolute, out Uri? uri)) {
-            ArchiSteamFarm.Core.ASF.ArchiLogger.LogGenericError("[FreeGames] Invalid redlib instances url: " + options.RedlibInstanceUrl);
-
-            return await ListFromEmbedded(cancellationToken).ConfigureAwait(false);
-        }
+			return await ListFromEmbedded(cancellationToken).ConfigureAwait(false);
+		}
 
 #pragma warning disable CAC001
 #pragma warning disable CA2007
-        await using HttpStreamResponse response = await httpClient.GetStreamAsync(uri!, cancellationToken: cancellationToken).ConfigureAwait(false);
+		await using HttpStreamResponse response = await httpClient.GetStreamAsync(uri, cancellationToken: cancellationToken).ConfigureAwait(false);
 #pragma warning restore CA2007
 #pragma warning restore CAC001
 
-        if (!response.StatusCode.IsSuccessCode()) {
-            return await ListFromEmbedded(cancellationToken).ConfigureAwait(false);
-        }
+		if (!response.StatusCode.IsSuccessCode()) {
+			return await ListFromEmbedded(cancellationToken).ConfigureAwait(false);
+		}
 
-        JsonNode? node = await ParseJsonNode(response, cancellationToken).ConfigureAwait(false);
+		JsonNode? node = await ParseJsonNode(response, cancellationToken).ConfigureAwait(false);
 
-        if (node is null) {
-            return await ListFromEmbedded(cancellationToken).ConfigureAwait(false);
-        }
+		if (node is null) {
+			return await ListFromEmbedded(cancellationToken).ConfigureAwait(false);
+		}
 
-        CheckUpToDate(node);
+		CheckUpToDate(node);
 
-        List<Uri> res = ParseUrls(node);
+		List<Uri> res = ParseUrls(node);
 
-        return res.Count > 0 ? res : await ListFromEmbedded(cancellationToken).ConfigureAwait(false);
-    }
+		return res.Count > 0 ? res : await ListFromEmbedded(cancellationToken).ConfigureAwait(false);
+	}
 
-    internal static void CheckUpToDate(JsonNode node) {
-        int currentYear = DateTime.Now.Year;
-        string updated = node["updated"]?.GetValue<string>() ?? "";
+	internal static void CheckUpToDate(JsonNode node) {
+		int currentYear = DateTime.Now.Year;
+		string updated = node["updated"]?.GetValue<string>() ?? "";
 
-        if (!updated.StartsWith(currentYear.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal) &&
-            !updated.StartsWith((currentYear - 1).ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)) {
-            throw new RedlibOutDatedListException();
-        }
-    }
+		if (!updated.StartsWith(currentYear.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal) &&
+			!updated.StartsWith((currentYear - 1).ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal)) {
+			throw new RedlibOutDatedListException();
+		}
+	}
 
-    internal static async Task<List<Uri>> ListFromEmbedded(CancellationToken cancellationToken) {
-        JsonNode? node = await LoadEmbeddedInstance(cancellationToken).ConfigureAwait(false);
+	internal static async Task<List<Uri>> ListFromEmbedded(CancellationToken cancellationToken) {
+		JsonNode? node = await LoadEmbeddedInstance(cancellationToken).ConfigureAwait(false);
 
-        if (node is null) {
+		if (node is null) {
 #pragma warning disable CA2201
-            throw new NullReferenceException($"unable to find embedded file {EmbeddedFileName}");
+			throw new NullReferenceException($"unable to find embedded file {EmbeddedFileName}");
 #pragma warning restore CA2201
-        }
+		}
 
-        CheckUpToDate(node);
+		CheckUpToDate(node);
 
-        return ParseUrls(node);
-    }
+		return ParseUrls(node);
+	}
 
-    internal static List<Uri> ParseUrls(JsonNode json) {
-        JsonNode? instances = json["instances"];
+	internal static List<Uri> ParseUrls(JsonNode json) {
+		JsonNode? instances = json["instances"];
 
-        if (instances is null) {
-            return new List<Uri>();
-        }
+		if (instances is null) {
+			return [];
+		}
 
-        List<Uri> uris = new(((JsonArray) instances).Count);
+		List<Uri> uris = new(((JsonArray) instances).Count);
 
-        // ReSharper disable once LoopCanBePartlyConvertedToQuery
-        foreach (JsonNode? instance in (JsonArray) instances) {
-            JsonNode? url = instance?["url"];
+		// ReSharper disable once LoopCanBePartlyConvertedToQuery
+		foreach (JsonNode? instance in (JsonArray) instances) {
+			JsonNode? url = instance?["url"];
 
-            if (Uri.TryCreate(url?.GetValue<string>() ?? "", UriKind.Absolute, out Uri? instanceUri) && instanceUri.Scheme is "http" or "https") {
-                uris.Add(instanceUri);
-            }
-        }
+			if (Uri.TryCreate(url?.GetValue<string>() ?? "", UriKind.Absolute, out Uri? instanceUri) && instanceUri.Scheme is "http" or "https") {
+				uris.Add(instanceUri);
+			}
+		}
 
-        return uris;
-    }
+		return uris;
+	}
 
-    private static bool IsDisabled(string? instanceUrl) => instanceUrl is not null && DisabledKeywords.Contains(instanceUrl.Trim());
+	private static bool IsDisabled(string? instanceUrl) => instanceUrl is not null && DisabledKeywords.Contains(instanceUrl.Trim());
 
-    private static async Task<JsonNode?> LoadEmbeddedInstance(CancellationToken cancellationToken) {
-        Assembly assembly = Assembly.GetExecutingAssembly();
+	private static async Task<JsonNode?> LoadEmbeddedInstance(CancellationToken cancellationToken) {
+		Assembly assembly = Assembly.GetExecutingAssembly();
 
 #pragma warning disable CAC001
 #pragma warning disable CA2007
-        await using Stream stream = assembly.GetManifestResourceStream($"{assembly.GetName().Name}.Resources.{EmbeddedFileName}")!;
+		await using Stream stream = assembly.GetManifestResourceStream($"{assembly.GetName().Name}.Resources.{EmbeddedFileName}")!;
 #pragma warning restore CA2007
 #pragma warning restore CAC001
 
-        using StreamReader reader = new(stream); // assume the encoding is UTF8, cannot be specified as per issue #91
-        string data = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+		using StreamReader reader = new(stream); // assume the encoding is UTF8, cannot be specified as per issue #91
+		string data = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
 
-        return JsonNode.Parse(data);
-    }
+		return JsonNode.Parse(data);
+	}
 
-    private static Task<JsonNode?> ParseJsonNode(HttpStreamResponse stream, CancellationToken cancellationToken) => RedditHelper.ParseJsonNode(stream, cancellationToken);
+	private static Task<JsonNode?> ParseJsonNode(HttpStreamResponse stream, CancellationToken cancellationToken) => RedditHelper.ParseJsonNode(stream, cancellationToken);
 }


### PR DESCRIPTION
Fix(tests): Replace `ConfigureAwait(false)` with `ConfigureAwait(true)`

Addresses xUnit analyzer warnings (xUnit1030) in test methods. The analyzer recommends against using `ConfigureAwait(false)` in tests as it can bypass parallelization limits and potentially cause issues with test parallelization.

This pull request replaces all instances of `ConfigureAwait(false)` with `ConfigureAwait(true)` within test methods. This ensures tests are executed in a way that respects parallelization limits and aligns with xUnit best practices for asynchronous testing.

This change resolves the reported build warnings related to `ConfigureAwait(false)` and may improve test execution reliability and adherence to xUnit recommendations.