### PR TITLE
fix misleading instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ ASF-FreeGames is a **[plugin](https://github.com/JustArchiNET/ArchiSteamFarm/wik
 
 ## Installation
 
-- 🔽 Download latest [Dll](https://github.com/maxisoft/ASFFreeGames/releases) from the release page
-- ➡️ Move the **dll** into the `plugins` folder of your *ArchiSteamFarm* installation
+- 🔽 Download latest [ASFFreeGames-generic.zip](https://github.com/maxisoft/ASFFreeGames/releases) from the release page
+- ➡️ Extract the **ZIP** and move the **extracted folder** into the `plugins` folder of your *ArchiSteamFarm* installation
 - 🔄 (re)start ArchiSteamFarm
 - 🎉 Have fun
 


### PR DESCRIPTION
Simply moving the .dll to "plugins" will prevent the plugin from working properly. The readme is updated to prevent any confusion

## Pull request

